### PR TITLE
Include `--contrib` flag by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,7 @@ async function run(): Promise<void> {
         const coursierBinDir = path.join(os.homedir(), 'cs', 'bin')
         core.exportVariable('COURSIER_BIN_DIR', coursierBinDir)
         core.addPath(coursierBinDir)
-        await cs('install', ...apps)
+        await cs('install', '--contrib', ...apps)
       }
     })
   } catch (error) {


### PR DESCRIPTION
Previously, it was not possible to install contrib applications like
lsif-java from the `apps` field.