### PR TITLE
Run tests against Java 17 rather than Java 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        jvm: ['8', '11']
+        jvm: ['8', '17']
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
(We keep the Java 8 tests alongside the Java 17.)