### PR TITLE
Fix `aarch` binaries download url

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,24 +7,24 @@ import * as tc from '@actions/tool-cache'
 const defaultVersion_x86_64 = '2.1.2'
 const defaultVersion_aarch64 = '2.1.1'
 
-const config = Object.freeze({
-  x86_64: {
-    csVersion: core.getInput('version') || defaultVersion_x86_64,
-    coursierVersionSpec: core.getInput('version') || defaultVersion_x86_64,
-    releasesDownloadBaseUrl: 'https://github.com/coursier/coursier/releases/download'
-  },
-  aarch64: {
-    csVersion: core.getInput('version') || defaultVersion_aarch64,
-    coursierVersionSpec: core.getInput('version') || defaultVersion_aarch64,
-    releasesDownloadBaseUrl: 'https://github.com/VirtusLab/coursier-m1/releases/download'
-  }
-})
+const architecture_x86_64 = 'x86_64'
+const architecture_aarch64 = 'aarch64'
+
+const architecture = getCoursierArchitecture()
+const csVersion = core.getInput('version') || (architecture == architecture_x86_64
+  ? architecture_x86_64
+  : architecture_aarch64
+)
+const coursierVersionSpec = csVersion
+const coursierBinariesGithubRepository = (architecture == architecture_x86_64)
+  ? 'https://github.com/coursier/coursier/'
+  : 'https://github.com/VirtusLab/coursier-m1/'
 
 function getCoursierArchitecture(): string {
   if (process.arch === 'x64') {
-    return 'x86_64'
+    return architecture_x86_64
   } else if (process.arch === 'arm' || process.arch === 'arm64') {
-    return 'aarch64'
+    return architecture_aarch64
   } else {
     throw new Error(`Coursier does not have support for the ${process.arch} architecture`)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function execOutput(cmd: string, ...args: string[]): Promise<string> {
 
 async function downloadCoursier(): Promise<string> {
   const architecture = getCoursierArchitecture()
-  const baseUrl = `https://github.com/coursier/coursier/releases/download/v${csVersion}/cs-${architecture}`
+  const baseUrl = `${coursierBinariesGithubRepository}/releases/download/v${csVersion}/cs-${architecture}`
   let csBinary = ''
   switch (process.platform) {
     case 'linux': {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,6 @@ async function execOutput(cmd: string, ...args: string[]): Promise<string> {
 }
 
 async function downloadCoursier(): Promise<string> {
-  const architecture = getCoursierArchitecture()
   const baseUrl = `${coursierBinariesGithubRepository}/releases/download/v${csVersion}/cs-${architecture}`
   let csBinary = ''
   switch (process.platform) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ const architecture_aarch64 = 'aarch64'
 
 const architecture = getCoursierArchitecture()
 const csVersion = core.getInput('version') || (architecture == architecture_x86_64
-  ? architecture_x86_64
-  : architecture_aarch64
+  ? defaultVersion_x86_64
+  : defaultVersion_aarch64
 )
 const coursierVersionSpec = csVersion
 const coursierBinariesGithubRepository = (architecture == architecture_x86_64)

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,15 +4,18 @@ import * as os from 'os'
 import * as path from 'path'
 import * as tc from '@actions/tool-cache'
 
+const defaultVersion_x86_64 = '2.1.2'
+const defaultVersion_aarch64 = '2.1.1'
+
 const config = Object.freeze({
   x86_64: {
-    csVersion: core.getInput('version') || '2.1.2',
-    coursierVersionSpec: core.getInput('version') || '2.1.2',
+    csVersion: core.getInput('version') || defaultVersion_x86_64,
+    coursierVersionSpec: core.getInput('version') || defaultVersion_x86_64,
     releasesDownloadBaseUrl: 'https://github.com/coursier/coursier/releases/download'
   },
   aarch64: {
-    csVersion: core.getInput('version') || '2.1.1',
-    coursierVersionSpec: core.getInput('version') || '2.1.1',
+    csVersion: core.getInput('version') || defaultVersion_aarch64,
+    coursierVersionSpec: core.getInput('version') || defaultVersion_aarch64,
     releasesDownloadBaseUrl: 'https://github.com/VirtusLab/coursier-m1/releases/download'
   }
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,12 @@ const architecture_x86_64 = 'x86_64'
 const architecture_aarch64 = 'aarch64'
 
 const architecture = getCoursierArchitecture()
-const csVersion = core.getInput('version') || (architecture == architecture_x86_64
+const csVersion = core.getInput('version') || (architecture === architecture_x86_64
   ? defaultVersion_x86_64
   : defaultVersion_aarch64
 )
 const coursierVersionSpec = csVersion
-const coursierBinariesGithubRepository = (architecture == architecture_x86_64)
+const coursierBinariesGithubRepository = (architecture === architecture_x86_64)
   ? 'https://github.com/coursier/coursier/'
   : 'https://github.com/VirtusLab/coursier-m1/'
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,18 @@ import * as os from 'os'
 import * as path from 'path'
 import * as tc from '@actions/tool-cache'
 
-const csVersion = core.getInput('version') || '2.1.2'
-
-const coursierVersionSpec = csVersion
+const config = Object.freeze({
+  x86_64: {
+    csVersion: core.getInput('version') || '2.1.2',
+    coursierVersionSpec: core.getInput('version') || '2.1.2',
+    releasesDownloadBaseUrl: 'https://github.com/coursier/coursier/releases/download'
+  },
+  aarch64: {
+    csVersion: core.getInput('version') || '2.1.1',
+    coursierVersionSpec: core.getInput('version') || '2.1.1',
+    releasesDownloadBaseUrl: 'https://github.com/VirtusLab/coursier-m1/releases/download'
+  }
+})
 
 function getCoursierArchitecture(): string {
   if (process.arch === 'x64') {


### PR DESCRIPTION
It looks like that from version [v2.1.0-RC4](https://github.com/coursier/coursier/releases/tag/v2.1.0-RC4) forwards the coursier `aarch64` binaries were moved from https://github.com/coursier/coursier repository to https://github.com/VirtusLab/coursier-m1.

This, unfortunately, invalidates the [previously added `aarch64` support](https://github.com/coursier/setup-action/pull/369) previously added for versions `>= v2.1.1`.

Fixing this by changing the target download URL based on the processor architecture!