### PR TITLE
Add custom repository variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Inspired by [olafurpg/setup-scala](https://github.com/olafurpg/setup-scala) and 
 - `apps` (optional): Scala apps to install (`sbtn` by default)
   - space separated list of app names (from the [main channel](https://github.com/coursier/apps))
 
+- `customRepositories` (optional): ''
+  - Pipe separated list of [repositories](https://get-coursier.io/docs/other-repositories) to supply to coursier
+
+- `disableDefaultRepos` (optional): 'false'
+  - Whether or not to pass the --no-default flag to coursier
+
 ### Example with custom inputs
 
 ```yml
@@ -36,6 +42,8 @@ Inspired by [olafurpg/setup-scala](https://github.com/olafurpg/setup-scala) and 
         jvm: adopt:11
         jvm-index: https://url/of/your/index.json
         apps: sbtn bloop ammonite
+        disableDefaultRepos: true
+        customRepositories: https://packages.corp.com/maven
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,14 @@ inputs:
     description: 'Coursier version to install'
     required: false
     default: ''
+  customRepositories:
+    description: 'The pipe (|) seperated locations of non-standard repositories. See https://get-coursier.io/docs/other-repositories'
+    required: false
+    default: ''
+  disableDefaultRepos:
+    description: 'Whether to pass the --no-default flag to coursier'
+    required: false
+    default: 'false'
 outputs:
   cs-version:
     description: 'Version of the installed Coursier'

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,23 @@ async function cs(...args: string[]): Promise<string> {
     const csCached = await tc.cacheFile(csBinary, binaryName, 'cs', csVersion)
     core.addPath(csCached)
   }
+  
+  const disableDefaultReposInput = core.getInput('disableDefaultRepos')
+
+  if (disableDefaultReposInput.toLowerCase() === 'true') {
+    args.push('--no-default')
+  }
+
+  const customRepositoryInput = core.getInput('customRepositories')
+  if (customRepositoryInput) {
+    const repositories = customRepositoryInput.split('|')
+
+    // For each repository, push the `-r` flag and the repository itself to the args list
+    repositories.forEach(repo => {
+      args.push('-r', repo.trim())
+    })
+  }
+
   return execOutput('cs', ...args)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,7 +95,7 @@ async function cs(...args: string[]): Promise<string> {
     const csCached = await tc.cacheFile(csBinary, binaryName, 'cs', csVersion)
     core.addPath(csCached)
   }
-  
+
   const disableDefaultReposInput = core.getInput('disableDefaultRepos')
 
   if (disableDefaultReposInput.toLowerCase() === 'true') {


### PR DESCRIPTION
For the situation, in which one is attempting to use this action in a (corporate) environment, where standard repositories are not available, but proxied by some other tool - e.g. antifactory. 